### PR TITLE
Update jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
+            <version>[2.9.10,)</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
CVE-2019-16942
Vulnerable versions: < 2.9.10.1
Patched version: 2.9.10.1

A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the commons-dbcp (1.4) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of org.apache.commons.dbcp.datasources.SharedPoolDataSource and org.apache.commons.dbcp.datasources.PerUserPoolDataSource mishandling.
